### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "style-loader": "^2.0.0",
     "webpack": "^5.27.0",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^3.11.2",
+    "mini-css-extract-plugin": "^1.6.0",
   }
 }


### PR DESCRIPTION
    "mini-css-extract-plugin" was missing from developer dependencies. Added it now.